### PR TITLE
Develop 1.1.0b

### DIFF
--- a/Biquads.jucer
+++ b/Biquads.jucer
@@ -2,7 +2,7 @@
 
 <JUCERPROJECT id="jER3fq" name="Biquads" projectType="audioplug" useAppConfig="1"
               addUsingNamespaceToJuceHeader="0" displaySplashScreen="1" jucerFormatVersion="1"
-              companyName="StoneyDSP" cppLanguageStandard="latest" version="1.0.16b"
+              companyName="StoneyDSP" cppLanguageStandard="latest" version="1.1.0b"
               pluginAUMainType="'aufx'" pluginVST3Category="Fx" pluginFormats="buildVST3"
               companyEmail="nathan@stoneydsp.com">
   <MAINGROUP id="butqEA" name="Biquads">

--- a/Biquads.jucer
+++ b/Biquads.jucer
@@ -13,6 +13,8 @@
         <FILE id="oNSzMK" name="AutoComponent.h" compile="0" resource="0" file="Source/Components/AutoComponent.h"/>
       </GROUP>
       <GROUP id="{9CCA4E58-A6DF-778D-0E47-615CE5201735}" name="Modules">
+        <FILE id="CkmJBA" name="Coefficient.cpp" compile="1" resource="0" file="Source/Modules/Coefficient.cpp"/>
+        <FILE id="cfbQWO" name="Coefficient.h" compile="0" resource="0" file="Source/Modules/Coefficient.h"/>
         <FILE id="unuiPg" name="SecondOrderBiquads.cpp" compile="1" resource="0"
               file="Source/Modules/SecondOrderBiquads.cpp"/>
         <FILE id="fw6I4S" name="SecondOrderBiquads.h" compile="0" resource="0"
@@ -58,7 +60,6 @@
         <MODULEPATH id="juce_gui_extra" path="../../Users/Nathan/DSP/JUCE/modules"/>
         <MODULEPATH id="juce_dsp" path="../../Users/Nathan/DSP/JUCE/modules"/>
         <MODULEPATH id="stoneydsp_filters" path="../../Users/Nathan/DSP/StoneyDSP/modules"/>
-        <MODULEPATH id="stoneydsp_maths" path="../../Users/Nathan/DSP/StoneyDSP/modules"/>
       </MODULEPATHS>
     </VS2022>
   </EXPORTFORMATS>
@@ -78,6 +79,5 @@
     <MODULE id="juce_gui_basics" showAllCode="1" useLocalCopy="0" useGlobalPath="1"/>
     <MODULE id="juce_gui_extra" showAllCode="1" useLocalCopy="0" useGlobalPath="1"/>
     <MODULE id="stoneydsp_filters" showAllCode="1" useLocalCopy="0" useGlobalPath="1"/>
-    <MODULE id="stoneydsp_maths" showAllCode="1" useLocalCopy="0" useGlobalPath="1"/>
   </MODULES>
 </JUCERPROJECT>

--- a/Source/Modules/Coefficient.cpp
+++ b/Source/Modules/Coefficient.cpp
@@ -1,0 +1,55 @@
+/*
+  ==============================================================================
+
+    Coefficient.cpp
+    Created: 6 Jul 2022 12:58:03am
+    Author:  Nathan J. Hood
+    Website: github.com/StoneyDSP
+    email:   nathanjhood@googlemail.com
+
+  ==============================================================================
+*/
+
+#include "Coefficient.h"
+
+template <typename SampleType>
+Coefficient<SampleType>::Coefficient(SampleType init) : value(init)
+{
+}
+
+template <typename SampleType>
+Coefficient<SampleType>::~Coefficient()
+{
+    static_assert (std::atomic<SampleType>::is_always_lock_free,
+        "Coefficient requires a lock-free std::atomic<float>");
+}
+
+template <typename SampleType>
+SampleType Coefficient<SampleType>::getValue() const
+{ 
+    return value;
+}
+
+template <typename SampleType>
+void Coefficient<SampleType>::setValue(SampleType newValue)
+{ 
+    value = newValue; 
+    valueChanged(get()); 
+}
+
+template <typename SampleType>
+void Coefficient<SampleType>::valueChanged(SampleType) 
+{
+}
+
+template <typename SampleType>
+Coefficient<SampleType>& Coefficient<SampleType>::operator= (SampleType newValue)
+{
+    if (value != newValue)
+        setValue(newValue);
+
+    return *this;
+}
+
+template class Coefficient<float>;
+template class Coefficient<double>;

--- a/Source/Modules/Coefficient.h
+++ b/Source/Modules/Coefficient.h
@@ -1,0 +1,50 @@
+/*
+  ==============================================================================
+
+    Coefficient.h
+    Created: 6 Jul 2022 12:58:03am
+    Author:  Nathan J. Hood
+    Website: github.com/StoneyDSP
+    email:   nathanjhood@googlemail.com
+
+  ==============================================================================
+*/
+
+#pragma once
+
+#ifndef COEFFICIENT_H_INCLUDED
+#define COEFFICIENT_H_INCLUDED
+
+#include <atomic>
+
+template <typename SampleType>
+class Coefficient
+{
+public:
+    Coefficient(SampleType init);
+    ~Coefficient();
+
+    /** Returns the coefficient's current value. */
+    SampleType get() const noexcept { return value; }
+
+    /** Returns the coefficient's current value. */
+    operator SampleType() const noexcept { return value; }
+
+    /** Changes the coefficient's current value. */
+    Coefficient& operator= (SampleType newValue);
+
+protected:
+    /** Override this method if you are interested in receiving callbacks
+        when the parameter value changes.
+    */
+    void valueChanged(SampleType newValue);
+
+private:
+    //==============================================================================
+    SampleType getValue() const;
+    void setValue(SampleType newValue);
+
+    std::atomic<SampleType> value;
+};
+
+#endif //COEFFICIENT_H_INCLUDED

--- a/Source/Modules/SecondOrderBiquads.cpp
+++ b/Source/Modules/SecondOrderBiquads.cpp
@@ -13,7 +13,10 @@
 
 //==============================================================================
 template <typename SampleType>
-Biquads<SampleType>::Biquads()
+Biquads<SampleType>::Biquads() 
+    : 
+    b0(one), b1(zero), b2(zero), a0(one), a1(zero), a2(zero), 
+    b_0(one), b_1(zero), b_2(zero), a_0(one), a_1(zero), a_2(zero)
 {
     reset();
 }
@@ -24,13 +27,14 @@ void Biquads<SampleType>::setFrequency(SampleType newFreq)
 {
     jassert(minFreq <= newFreq && newFreq <= maxFreq);
 
-    if (hz != juce::jlimit(minFreq, maxFreq, newFreq))
+    if (hz != newFreq)
     {
-        hz = newFreq;
+        hz = juce::jlimit(minFreq, maxFreq, newFreq);
 
         omega = (hz * ((pi * two) / static_cast <SampleType>(sampleRate)));
         cos = (std::cos(omega));
         sin = (std::sin(omega));
+
         calculateCoefficients();
     }
 }
@@ -40,11 +44,10 @@ void Biquads<SampleType>::setResonance(SampleType newRes)
 {
     jassert(zero <= newRes && newRes <= one);
 
-    if (q != juce::jlimit(SampleType(0.0), SampleType(1.0), newRes))
+    if (q != newRes)
     {
-        q = newRes;
+        q = juce::jlimit(SampleType(0.0), SampleType(1.0), newRes);
 
-        alpha = (sin * (one - q));
         calculateCoefficients();
     }
 }
@@ -56,8 +59,6 @@ void Biquads<SampleType>::setGain(SampleType newGain)
     {
         g = newGain;
 
-        a = (std::pow(SampleType(10), (g * SampleType(0.05))));
-        sqrtA = ((std::sqrt(a) * two) * alpha);
         calculateCoefficients();
     }
 }
@@ -223,7 +224,7 @@ SampleType Biquads<SampleType>::directFormIITransposed(int channel, SampleType i
 
     Yn = ((Xn * b0) + (Xn2));
 
-    Xn2 = ((Xn * b1) + (Xn1)+(Yn * a1));
+    Xn2 = ((Xn * b1) + (Xn1) + (Yn * a1));
     Xn1 = ((Xn * b2) + (Yn * a2));
 
     return Yn;
@@ -236,11 +237,12 @@ void Biquads<SampleType>::calculateCoefficients()
     cos = (std::cos(omega));
     sin = (std::sin(omega));
     tan = (sin / cos);
+    juce::ignoreUnused(tan);*/
+
     alpha = (sin * (one - q));
     a = (std::pow(SampleType(10), (g * SampleType(0.05))));
     sqrtA = ((std::sqrt(a) * two) * alpha);
 
-    juce::ignoreUnused(tan);*/
 
     switch (filtType)
     {
@@ -437,8 +439,8 @@ void Biquads<SampleType>::calculateCoefficients()
     }
 
     a0 = (one / a_0);
-    a1 = ((a_1 * minusOne) * a0);
-    a2 = ((a_2 * minusOne) * a0);
+    a1 = ((-a_1) * a0);
+    a2 = ((-a_2) * a0);
     b0 = (b_0 * a0);
     b1 = (b_1 * a0);
     b2 = (b_2 * a0);

--- a/Source/Modules/SecondOrderBiquads.cpp
+++ b/Source/Modules/SecondOrderBiquads.cpp
@@ -233,12 +233,6 @@ SampleType Biquads<SampleType>::directFormIITransposed(int channel, SampleType i
 template <typename SampleType>
 void Biquads<SampleType>::calculateCoefficients()
 {
-    /*omega = (hz * ((pi * two) / static_cast <SampleType>(sampleRate)));
-    cos = (std::cos(omega));
-    sin = (std::sin(omega));
-    tan = (sin / cos);
-    juce::ignoreUnused(tan);*/
-
     alpha = (sin * (one - q));
     a = (std::pow(SampleType(10), (g * SampleType(0.05))));
     sqrtA = ((std::sqrt(a) * two) * alpha);

--- a/Source/Modules/SecondOrderBiquads.h
+++ b/Source/Modules/SecondOrderBiquads.h
@@ -17,6 +17,8 @@
 
 #include <JuceHeader.h>
 
+#include "Coefficient.h"
+
 enum struct FilterType
 {
     lowPass2 = 0,
@@ -127,12 +129,14 @@ public:
     SampleType processSample(int channel, SampleType inputValue);
 
     //==============================================================================
-    /*SampleType geta0() { return a0; }
+    SampleType geta0() { return a0; }
     SampleType getb0() { return b0; }
     SampleType geta1() { return a1; }
     SampleType getb1() { return b1; }
     SampleType geta2() { return a2; }
-    SampleType getb2() { return b2; }*/
+    SampleType getb2() { return b2; }
+
+    double sampleRate = 44100.0;
 
 private:
     //==========================================================================
@@ -143,27 +147,16 @@ private:
     SampleType directFormITransposed(int channel, SampleType inputValue);
     SampleType directFormIITransposed(int channel, SampleType inputValue);
 
-    double sampleRate = 44100.0;
-
     //==========================================================================
     /** Unit-delay object */
     std::vector<SampleType> Wn_1, Wn_2, Xn_1, Xn_2, Yn_1, Yn_2;
 
     //==========================================================================
-    /** Initialised coefficient gain */
-    SampleType b0 = 1.0;
-    SampleType b1 = 0.0;
-    SampleType b2 = 0.0;
-    SampleType a0 = 1.0;
-    SampleType a1 = 0.0;
-    SampleType a2 = 0.0;
+    /** Coefficient gain */
+    Coefficient<SampleType> b0, b1, b2, a0, a1, a2;
 
-    SampleType b_0 = 1.0;
-    SampleType b_1 = 0.0;
-    SampleType b_2 = 0.0;
-    SampleType a_0 = 1.0;
-    SampleType a_1 = 0.0;
-    SampleType a_2 = 0.0;
+    /** Coefficient calculation */
+    Coefficient<SampleType> b_0, b_1, b_2, a_0, a_1, a_2;
 
     //==========================================================================
     /** Initialised parameter */

--- a/Source/Modules/SecondOrderBiquads.h
+++ b/Source/Modules/SecondOrderBiquads.h
@@ -136,8 +136,6 @@ public:
     SampleType geta2() { return a2; }
     SampleType getb2() { return b2; }
 
-    double sampleRate = 44100.0;
-
 private:
     //==========================================================================
     void calculateCoefficients();
@@ -171,6 +169,7 @@ private:
     /** Initialised constant */
     const SampleType zero = 0.0, one = 1.0, two = 2.0, minusOne = -1.0, minusTwo = -2.0;
     const SampleType pi = juce::MathConstants<SampleType>::pi;
+    double sampleRate = 44100.0;
 
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(Biquads)
 };

--- a/Source/PluginEditor.cpp
+++ b/Source/PluginEditor.cpp
@@ -18,7 +18,7 @@ BiquadsAudioProcessorEditor::BiquadsAudioProcessorEditor (BiquadsAudioProcessor&
     undoManager(p.getUndoManager()),
     subComponents(p, p.getAPVTS())
 {
-    setSize(400, 300);
+    setSize(430, 300);
     addAndMakeVisible(subComponents);
     addAndMakeVisible(undoButton);
     addAndMakeVisible(redoButton);

--- a/Source/PluginParameters.cpp
+++ b/Source/PluginParameters.cpp
@@ -66,23 +66,23 @@ void Parameters::setParameterLayout(Params& params)
 
     params.add
         //======================================================================
-        (std::make_unique<juce::AudioProcessorParameterGroup>("masterID", "1", "seperatorA",
-            //==================================================================
-            std::make_unique<juce::AudioParameterChoice>("transformID", "Transform", tString, 3),
-            std::make_unique<juce::AudioParameterChoice>("osID", "Oversampling", osString, 0),
-            std::make_unique<juce::AudioParameterFloat>("outputID", "Output", outputRange, 00.00f, outputAttributes),
-            std::make_unique<juce::AudioParameterFloat>("mixID", "Mix", mixRange, 100.00f, mixAttributes)
-            //==================================================================
-            ));
-
-    params.add
-        //======================================================================
-        (std::make_unique<juce::AudioProcessorParameterGroup>("BandOneID", "0", "seperatorB",
+        (std::make_unique<juce::AudioProcessorParameterGroup>("BandOneID", "0", "seperatorA",
             //==================================================================
             std::make_unique<juce::AudioParameterFloat>("frequencyID", "Frequency", freqRange, 632.455f, freqAttributes),
             std::make_unique<juce::AudioParameterFloat>("resonanceID", "Resonance", resRange, 00.10f, resoAttributes),
             std::make_unique<juce::AudioParameterFloat>("gainID", "Gain", gainRange, 00.00f, gainAttributes),
             std::make_unique<juce::AudioParameterChoice>("typeID", "Type", fString, 0)
+            //==================================================================
+            ));
+
+    params.add
+        //======================================================================
+        (std::make_unique<juce::AudioProcessorParameterGroup>("masterID", "1", "seperatorB",
+            //==================================================================
+            std::make_unique<juce::AudioParameterChoice>("transformID", "Transform", tString, 3),
+            std::make_unique<juce::AudioParameterChoice>("osID", "Oversampling", osString, 0),
+            std::make_unique<juce::AudioParameterFloat>("outputID", "Output", outputRange, 00.00f, outputAttributes),
+            std::make_unique<juce::AudioParameterFloat>("mixID", "Mix", mixRange, 100.00f, mixAttributes)
             //==================================================================
             ));
 }

--- a/Source/PluginParameters.cpp
+++ b/Source/PluginParameters.cpp
@@ -71,8 +71,7 @@ void Parameters::setParameterLayout(Params& params)
             std::make_unique<juce::AudioParameterChoice>("transformID", "Transform", tString, 3),
             std::make_unique<juce::AudioParameterChoice>("osID", "Oversampling", osString, 0),
             std::make_unique<juce::AudioParameterFloat>("outputID", "Output", outputRange, 00.00f, outputAttributes),
-            std::make_unique<juce::AudioParameterFloat>("mixID", "Mix", mixRange, 100.00f, mixAttributes),
-            std::make_unique<juce::AudioParameterBool>("bypassID", "Bypass", false)
+            std::make_unique<juce::AudioParameterFloat>("mixID", "Mix", mixRange, 100.00f, mixAttributes)
             //==================================================================
             ));
 

--- a/Source/PluginProcessor.cpp
+++ b/Source/PluginProcessor.cpp
@@ -173,26 +173,26 @@ bool BiquadsAudioProcessor::isBusesLayoutSupported (const BusesLayout& layouts) 
 
 void BiquadsAudioProcessor::processBlock(juce::AudioBuffer<float>& buffer, juce::MidiBuffer& midiMessages)
 {
-    //if (bypassState->get())
-    //{
-    //    processBlockBypassed(buffer, midiMessages);
-    //}
+    if (bypassState->get())
+    {
+        processBlockBypassed(buffer, midiMessages);
+    }
 
-    //else
-    //{
-    //    juce::ScopedNoDenormals noDenormals;
+    else
+    {
+        juce::ScopedNoDenormals noDenormals;
 
-    //    processorFloat.process(buffer, midiMessages);
-    //}
+        processorFloat.process(buffer, midiMessages);
+    }
 
-    juce::ScopedNoDenormals noDenormals;
+    /*juce::ScopedNoDenormals noDenormals;
 
-    processorFloat.process(buffer, midiMessages);
+    processorFloat.process(buffer, midiMessages);*/
 }
 
 void BiquadsAudioProcessor::processBlock(juce::AudioBuffer<double>& buffer, juce::MidiBuffer& midiMessages)
 {
-    /*if (bypassState->get())
+    if (bypassState->get())
     {
         processBlockBypassed(buffer, midiMessages);
     }
@@ -202,11 +202,11 @@ void BiquadsAudioProcessor::processBlock(juce::AudioBuffer<double>& buffer, juce
         juce::ScopedNoDenormals noDenormals;
 
         processorDouble.process(buffer, midiMessages);
-    }*/
+    }
 
-    juce::ScopedNoDenormals noDenormals;
+    /*juce::ScopedNoDenormals noDenormals;
 
-    processorDouble.process(buffer, midiMessages);
+    processorDouble.process(buffer, midiMessages);*/
 }
 
 void BiquadsAudioProcessor::processBlockBypassed(juce::AudioBuffer<float>& buffer, juce::MidiBuffer& midiMessages)

--- a/Source/PluginProcessor.cpp
+++ b/Source/PluginProcessor.cpp
@@ -20,8 +20,11 @@ BiquadsAudioProcessor::BiquadsAudioProcessor()
     spec (),
     parameters (*this),
     processorFloat (*this),
-    processorDouble (*this)
+    processorDouble (*this),
+    bypassState (dynamic_cast<juce::AudioParameterBool*>(apvts.getParameter("bypassID"))),
+    processingPrecision(singlePrecision)
 {
+    jassert(bypassState != nullptr);
 }
 
 BiquadsAudioProcessor::~BiquadsAudioProcessor()
@@ -246,6 +249,8 @@ juce::AudioProcessorEditor* BiquadsAudioProcessor::createEditor()
 juce::AudioProcessorValueTreeState::ParameterLayout BiquadsAudioProcessor::createParameterLayout()
 {
     APVTS::ParameterLayout params;
+
+    params.add(std::make_unique<juce::AudioParameterBool>("bypassID", "Bypass", false));
 
     Parameters::setParameterLayout(params);
 

--- a/Source/PluginProcessor.h
+++ b/Source/PluginProcessor.h
@@ -108,9 +108,7 @@ private:
 
     //==========================================================================
     /** Init variables. */
-    double currentSampleRate = 0;
-    int blockSize = 0, latencySamples = 0;
-    ProcessingPrecision processingPrecision = singlePrecision;
+    ProcessingPrecision processingPrecision;
 
     //==========================================================================
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR (BiquadsAudioProcessor)

--- a/Source/PluginWrapper.cpp
+++ b/Source/PluginWrapper.cpp
@@ -19,7 +19,7 @@ ProcessWrapper<SampleType>::ProcessWrapper(BiquadsAudioProcessor& p)
     setup (p.getSpec()),
     mixer (),
     biquad (),
-    output (), 
+    output (),
     frequencyPtr (dynamic_cast <juce::AudioParameterFloat*> (p.getAPVTS().getParameter("frequencyID"))),
     resonancePtr (dynamic_cast <juce::AudioParameterFloat*> (p.getAPVTS().getParameter("resonanceID"))),
     gainPtr (dynamic_cast <juce::AudioParameterFloat*> (p.getAPVTS().getParameter("gainID"))),
@@ -133,7 +133,7 @@ template <typename SampleType>
 void ProcessWrapper<SampleType>::update()
 {
     mixer.setWetMixProportion(mixPtr->get() * 0.01f);
-    biquad.setFrequency(frequencyPtr->get());
+    biquad.setFrequency(frequencyPtr->get() / oversamplingFactor);
     biquad.setResonance(resonancePtr->get());
     biquad.setGain(gainPtr->get());
     biquad.setFilterType(static_cast<FilterType>(typePtr->getIndex()));
@@ -150,7 +150,6 @@ void ProcessWrapper<SampleType>::setOversampling()
         oversamplingFactor = 1 << curOS;
         prevOS = curOS;
         mixer.reset();
-        biquad.sampleRate = setup.sampleRate * oversamplingFactor;
         biquad.reset();
         output.reset();
     }

--- a/Source/PluginWrapper.cpp
+++ b/Source/PluginWrapper.cpp
@@ -150,6 +150,7 @@ void ProcessWrapper<SampleType>::setOversampling()
         oversamplingFactor = 1 << curOS;
         prevOS = curOS;
         mixer.reset();
+        biquad.sampleRate = setup.sampleRate * oversamplingFactor;
         biquad.reset();
         output.reset();
     }

--- a/Source/PluginWrapper.h
+++ b/Source/PluginWrapper.h
@@ -29,7 +29,7 @@ public:
     /** Constructor. */
     ProcessWrapper(BiquadsAudioProcessor& p);
 
-    //==============================================================================
+    ////==============================================================================
     ///** Sets the length of the ramp used for smoothing parameter changes. */
     //void setRampDurationSeconds(double newDurationSeconds) noexcept;
 
@@ -75,8 +75,6 @@ private:
     juce::dsp::DryWetMixer<SampleType> mixer;
     Biquads<SampleType> biquad;
     juce::dsp::Gain<SampleType> output;
-
-    //stoneydsp::filters::Biquads<SampleType> biquad;
 
     //==========================================================================
     /** Parameter pointers. */


### PR DESCRIPTION
- Implemented templated & fully atomic Coefficient object for full thread-safety assurance
- Moved all necessary memory acquisitions to init stage (RAII)
- Placed coeff calculations so to trigger only on param change callbacks, _not_ on function calls
- Moved Omega/Sin/Cos calcs into setFreq() param change callback
- Coeff calcs are now atomically handed to Coeff objects on param change thread, to be safely/atomically read (only!) from audio thread
- Logically re-organized parameter list when Editor is disabled (using DAW native GUI)
- Slight increaze in GUI width